### PR TITLE
Modify regex to support resources inside modules

### DIFF
--- a/aws_icons.py
+++ b/aws_icons.py
@@ -54,7 +54,7 @@ def repl_func(matchobj):
 def main():
     text = sys.stdin.read()
 
-    new_text = re.sub(r'label = "((aws_.+)\..+)",', repl_func, text)
+    new_text = re.sub(r'label = "(?:module\..*?\.){0,1}((aws_.+)\..+)",', repl_func, text)
 
     sys.stdout.write(new_text)
 


### PR DESCRIPTION
Fixes a bug where resources inside modules aren't iconified, by modifying the regex to match on an optional `module.xxx.` prefix.